### PR TITLE
Updates for Azure CLI, Kubernetes CLI and the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,5 @@
-FROM azuresdk/azure-cli-python:2.0.21
+# https://hub.docker.com/r/azuresdk/azure-cli-python/
+FROM azuresdk/azure-cli-python:2.0.22
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 RUN \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/azuresdk/azure-cli-python/
-FROM azuresdk/azure-cli-python:2.0.22
+FROM azuresdk/azure-cli-python:2.0.23
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 RUN \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 # Install the "kubectl" CLI
 # https://storage.googleapis.com/kubernetes-release/release/stable.txt
-ARG KUBECTL_VERSION="v1.7.7"
+ARG KUBECTL_VERSION="v1.9.0"
 RUN \
   curl -sSL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
   chmod +x /usr/local/bin/kubectl && \

--- a/dockercfg-generator/Dockerfile.test
+++ b/dockercfg-generator/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 LABEL maintainer='Codeship Inc <maintainers@codeship.com>'
 
 RUN echo "Hello Microsoft Azure at $(date)" > hello.txt


### PR DESCRIPTION
Updated to the latest version of both the Azure CLI (v2.0.23), `kubectl` (v1.9.0) and the `alpine` base image (v3.7) for the test images.

This requires a (currently) unreleased Azure CLI version, because of Azure/azure-cli#5060