### PR TITLE
Update to Azure CLI 2.0.67

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,3 +1,2 @@
-# https://hub.docker.com/r/microsoft/azure-cli/
-FROM microsoft/azure-cli:2.0.61
+FROM mcr.microsoft.com/azure-cli:2.0.67
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'


### PR DESCRIPTION
Also switched to [Microsoft's container registry](https://docs.microsoft.com/en-us/cli/azure/run-azure-cli-docker?view=azure-cli-latest):

> The Azure CLI has migrated to Microsoft Container Registry. Existing tags on Docker Hub are still supported, but new releases will only be available as mcr.microsoft.com/azure-cli.